### PR TITLE
Fix BigInt error

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -1148,5 +1148,7 @@ export function prepare(c, query) {
   `,
   ).bind({ p, _tm, ctx, _tms, duck, utf8e, ltype_gc, result_gc });
 
+  ctx.c = null;
+
   return ctx;
 }

--- a/lib.js
+++ b/lib.js
@@ -4,7 +4,7 @@ function ptr(v) {
   return Deno.UnsafePointer.of(v);
 }
 function toArrayBuffer(v, start, offset) {
-  const view = new Deno.UnsafePointerView(BigInt(v));
+  const view = new Deno.UnsafePointerView(v);
   return view.getArrayBuffer(start, offset);
 }
 function getCString(v) {
@@ -855,7 +855,7 @@ export function prepare(c, query) {
         ctx.query = new Function(${names.map((n) => `'${n}', `).join("")} \`
           function ptr(v) { return Deno.UnsafePointer.of(v) };
           function toArrayBuffer(v, start, offset) { 
-            const view = new Deno.UnsafePointerView(BigInt(v));
+            const view = new Deno.UnsafePointerView(v);
           }
           const { p, _tm, duck, utf8e, bitmap_get } = this;
 

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -24,7 +24,12 @@ Deno.test("BigInt issue in prepare statement", () => {
   assertObjectMatch(
     prepared.query(1337, "foo")[0],
     { number: 1337, text: "foo" }
-  )
+  );
+  
+  assertObjectMatch(
+    prepared.query(null, "bar")[0],
+    { number: 0, text: "bar" }
+  );
 
   connection.close();
   db.close();

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,0 +1,31 @@
+import { assertObjectMatch } from "https://deno.land/std@0.195.0/testing/asserts.ts";
+
+import { open } from './mod.ts';
+
+Deno.test("BigInt issue in query statement", () => {
+  const db = open(":memory:")
+  const connection = db.connect();
+  assertObjectMatch(
+    connection.query("SELECT 1234 AS result")[0],
+    { result: 1234 }
+  )
+  connection.close();
+  db.close();
+});
+
+Deno.test("BigInt issue in prepare statement", () => {
+  const db = open(":memory:")
+  const connection = db.connect();
+
+  const prepared = connection.prepare(
+    "select ?::INTEGER as number, ?::VARCHAR as text",
+  );
+  
+  assertObjectMatch(
+    prepared.query(1337, "foo")[0],
+    { number: 1337, text: "foo" }
+  )
+
+  connection.close();
+  db.close();
+});


### PR DESCRIPTION
The call to BigInt in toArrayBuffer() was causing the following error.

```js
error: TypeError: Cannot convert object to primitive value
  const view = new Deno.UnsafePointerView(BigInt(v));
```

Results seem OK without.

Running

deno 1.35.0 (release, x86_64-unknown-linux-gnu)
v8 11.6.189.7
typescript 5.1.6

Closes #3