### PR TITLE
perf improvement for prepared query

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -61,6 +61,7 @@ const { symbols: duck } = await plugPrepare(options, {
   duckffi_open: { parameters: ["u8", "pointer"], result: "pointer" },
   duckffi_query: { parameters: ["pointer", "pointer"], result: "pointer" },
   duckffi_free_result: { parameters: ["pointer"], result: "void" },
+  duckffi_reset_result: { parameters: ["pointer"], result: "void" },
   duckffi_column_count: { parameters: ["pointer"], result: "u32" },
   duckffi_result_error: { parameters: ["pointer"], result: "pointer" },
   duckffi_free_prepare: { parameters: ["pointer"], result: "void" },
@@ -68,6 +69,7 @@ const { symbols: duck } = await plugPrepare(options, {
   duckffi_prepare: { parameters: ["pointer", "pointer"], result: "pointer" },
   duckffi_row_count_slow: { parameters: ["pointer"], result: "u64" },
   duckffi_query_prepared: { parameters: ["pointer"], result: "pointer" },
+  duckffi_execute_prepared: { parameters: ["pointer", "pointer"], result: "u32" },
   duckffi_row_count_large: { parameters: ["pointer"], result: "u8" },
   duckffi_param_type: { parameters: ["pointer", "u32"], result: "u32" },
   duckffi_enum_string: { parameters: ["pointer", "u32"], result: "pointer" },
@@ -831,7 +833,7 @@ export function prepare(c, query) {
 
       if (e) {
         const s = getCString(e);
-        throw (duck.duckffi_free_result(r), new Error(s));
+        throw (duck.duckffi_reset_result(r), new Error(s));
       }
     }
 
@@ -857,7 +859,7 @@ export function prepare(c, query) {
           function toArrayBuffer(v, start, offset) { 
             const view = new Deno.UnsafePointerView(v);
           }
-          const { p, _tm, duck, utf8e, bitmap_get } = this;
+          const { p, _tm, duck, utf8e, bitmap_get, r } = this;
 
           ${
       names.map((name, offset) => `
@@ -872,53 +874,34 @@ export function prepare(c, query) {
             }
           `).join("\n")
     }
-
-          const r = duck.duckffi_query_prepared(p);
-
-          {
+          if (duck.duckffi_execute_prepared(p, r) === 1) {
             const e = duck.duckffi_result_error(r);
-
             if (e) {
               const s = new CString(e);
-              throw (duck.duckffi_free_result(r), new Error(s));
+              throw (duck.duckffi_reset_result(r), new Error(s));
             }
           }
 
           const rows = duck.duckffi_row_count(r);
+          if (0 === rows) return (duck.duckffi_reset_result(r), []);
           const ltypes = new Array(\${ltypes.length});
-          if (0 === rows) return (duck.duckffi_free_result(r), []);
 
           \${types.map((type, column) => \`
             const _tm_\${column}_\${type} = _tm[\${type}](r, ltypes, \${column});
-            const nulls_\${column} = duck.duckffi_null_bitmap(r, rows, \${column});
-            const nulls_view_\${column} = new Uint8Array(toArrayBuffer(nulls_\${column}, 0, Math.ceil(rows / 8)));
           \`).join('\\n')}
 
-          try {
             const a = new Array(rows);
-
             for (let offset = 0; rows > offset; offset++) {
               a[offset] = {
                 \${names.map((name, column) => \`
-                  "\${name}": (bitmap_get(nulls_view_\${column}, offset)) ? null : _tm_\${column}_\${types[column]}(offset, \${column}),
+                    "\${name}": duck.duckffi_value_is_null(r, \${column}, offset) ? null : _tm_\${column}_\${types[column]}(offset, \${column}),
                 \`.trim()).join('\\n')}
               };
             }
-
+            duck.duckffi_reset_result(r);
             return a;
-          } finally {
-            for (let offset = 0; \${ltypes.length} > offset; offset++) {
-              const x = ltypes[offset];
-              if (x) duck.duckffi_free_ltype(x);
-            }
+        \`).bind({ p, _tm, ctx, duck, utf8e, bitmap_get, r });
 
-            \${new Array(columns).fill(0).map((_, column) => \`
-              duck.duckffi_free(nulls_\${column});
-            \`).join('\\n')}
-
-            duck.duckffi_free_result(r);
-          }
-        \`).bind({ p, _tm, ctx, duck, utf8e, bitmap_get });
       }
 
       for (let offset = 0; rows > offset; offset++) {
@@ -942,7 +925,7 @@ export function prepare(c, query) {
         if (x) duck.duckffi_free_ltype(x);
       }
 
-      duck.duckffi_free_result(r);
+      duck.duckffi_reset_result(r);
     }
   `,
   ).bind({ p, _tm, ctx, duck, utf8e, bitmap_get });

--- a/src/sql.c
+++ b/src/sql.c
@@ -7,6 +7,7 @@ void duckffi_dfree(void* ptr) { duckdb_free(ptr); }
 void duckffi_free_blob(duckdb_blob* blob) { duckdb_free(blob->data); free(blob); }
 void duckffi_close(duckdb_database db) { duckdb_database d = db; duckdb_close(&d); }
 void duckffi_free_result(duckdb_result* result) { duckdb_destroy_result(result); free(result); }
+void duckffi_reset_result(duckdb_result* result) { duckdb_destroy_result(result); }
 void duckffi_disconnect(duckdb_connection con) { duckdb_connection c = con; duckdb_disconnect(&c); }
 void duckffi_free_ltype(duckdb_logical_type ltype) { duckdb_logical_type t = ltype; duckdb_destroy_logical_type(&t); }
 void duckffi_free_prepare(duckdb_prepared_statement prepare) { duckdb_prepared_statement p = prepare; duckdb_destroy_prepare(&p); }
@@ -32,6 +33,7 @@ duckdb_result* duckffi_query_prepared(duckdb_prepared_statement prepare) {
 }
 
 void* duckffi_blob_data(duckdb_blob* blob) { return blob->data; }
+uint32_t duckffi_execute_prepared(duckdb_prepared_statement prepared, duckdb_result* res) { return duckdb_execute_prepared(prepared, res); }
 uint32_t duckffi_blob_size(duckdb_blob* blob) { return blob->size; }
 uint32_t duckffi_row_count(duckdb_result* result) { return duckdb_row_count(result); }
 uint64_t duckffi_row_count_slow(duckdb_result* result) { return duckdb_row_count(result); }

--- a/src/sql.h
+++ b/src/sql.h
@@ -6,6 +6,7 @@ void duckffi_close(duckdb_database db);
 void duckffi_free_blob(duckdb_blob* blob);
 void duckffi_disconnect(duckdb_connection con);
 void duckffi_free_result(duckdb_result* result);
+void duckffi_reset_result(duckdb_result* result);
 void duckffi_free_ltype(duckdb_logical_type ltype);
 void duckffi_free_prepare(duckdb_prepared_statement prepare);
 
@@ -15,6 +16,7 @@ duckdb_result* duckffi_query(duckdb_connection con, const char* query);
 duckdb_result* duckffi_query_prepared(duckdb_prepared_statement prepare);
 duckdb_prepared_statement duckffi_prepare(duckdb_connection con, const char* query);
 
+uint32_t duckffi_execute_prepared(duckdb_prepared_statement prepared, duckdb_result* res);
 void* duckffi_blob_data(duckdb_blob* blob);
 uint32_t duckffi_blob_size(duckdb_blob* blob);
 uint32_t duckffi_row_count(duckdb_result* result);


### PR DESCRIPTION
I did some benchmarking on lo against this and, after understanding what the code here is doing, these changes should result in a ~20% improvement in throughput for this simple bench. i tested on 0.4.0 of duckdb shared library and using this command to run:

```
DENO_DUCKDB_DEV=1 LD_PRELOAD=../duckdb/0.4.0/libduckdb.so nice -n 20 taskset --cpu-list 0 deno run -A --unstable test.js
```

i see 60k rps for these changes, ~51k rps for HEAD.

Bun with @evan/duckdb is 49k rps for the same bench on my setup. Bun is also ~50 MB more memory usage.

```JavaScript
import { open } from "./mod.ts";

const db = open(":memory:");

const connection = db.connect();

connection.query('CREATE TABLE integers(i INTEGER, j INTEGER);');
connection.query('INSERT INTO integers VALUES (3, 4), (5, 6), (7, NULL);');

const prepared = connection.prepare('SELECT * FROM integers;');

const runs = 100000

while (1) {
  const start = Date.now()
  for (let i = 0; i < runs; i++) {
    prepared.query()    
  }
  const elapsed = Date.now() - start
  const rate = runs / (elapsed / 1000)
  const ms_iter = elapsed / runs
  const { rss } = Deno.memoryUsage()
  console.log(`runs ${runs} rate ${rate} ms_iter ${ms_iter} rss ${rss}`)
}

connection.close();
db.close();

```

there is further work to do be done to apply this to the other methods and i need to check to see if this doesn't break something existing, so just submitting as a draft for discussion for now.